### PR TITLE
Enforce uppercase for markdown file API.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "baldrick-doc-ts",
   "description": "fixme",
   "keywords": ["cli"],
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": {
     "name": "Olivier Huin",
     "url": "https://github.com/olih"

--- a/src/commanding-action.ts
+++ b/src/commanding-action.ts
@@ -12,7 +12,7 @@ export const cmdGenerateTypedocAction: GenerateTypedocAction = async (
   await updateAll(ctx, options);
   ctx.termFormatter({
     title: 'Generated typedoc documentation',
-    detail: ['Check the generated api.md'].join('\n'),
+    detail: ['Check the generated API.md'].join('\n'),
     kind: 'info',
     format: 'default',
   });

--- a/src/io-sfx.ts
+++ b/src/io-sfx.ts
@@ -16,7 +16,7 @@ const writeApiMd = async (
 ) => {
   const content = toTypedocApiMd(opts, typedocJson);
   const filename =
-    opts.docBase.length > 0 ? `${opts.docBase}-api.md` : 'api.md';
+    opts.docBase.length > 0 ? `${opts.docBase}_API.md` : 'API.md';
   await writeFile(filename, content, 'utf8');
 };
 

--- a/src/markdown-api.ts
+++ b/src/markdown-api.ts
@@ -3,6 +3,9 @@ import { GenerateTypedocActionOpts, MdSection } from './model.js';
 import { Parameter, TypedocChild, TypedocJson } from './typedoc-json-model.js';
 const bq = '`';
 
+const apiFilename = (opts: GenerateTypedocActionOpts) =>
+  opts.docBase.length > 0 ? `${opts.docBase}_API.md` : 'API.md';
+
 const parameterToString = (param: Parameter): string => {
   const { name, type, comment } = param;
   const description = comment?.shortText || 'fixme: Adds a description';
@@ -70,7 +73,7 @@ const variableToMdSection =
 const titleToRef =
   (opts: GenerateTypedocActionOpts) =>
   (section: MdSection): string =>
-    `* [${section.title}](${opts.docBase}api.md#${section.title})`;
+    `* [${section.title}](${apiFilename(opts)}#${section.title})`;
 
 export const toTypedocApiMd = (
   opts: GenerateTypedocActionOpts,

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.5.0';
+export const version = '0.6.0';

--- a/test/__snapshots__/markdown-api.test.ts.snap
+++ b/test/__snapshots__/markdown-api.test.ts.snap
@@ -7,15 +7,15 @@ exports[`markdown-api should provide markdown for a docBase 1`] = `
 
 __Functions:__
 
-* [abstractObject](docs/my-api.md#abstractObject)
-* [anyOfString](docs/my-api.md#anyOfString)
-* [mutateObject](docs/my-api.md#mutateObject)
-* [someUrl](docs/my-api.md#someUrl)
+* [abstractObject](docs/my-_API.md#abstractObject)
+* [anyOfString](docs/my-_API.md#anyOfString)
+* [mutateObject](docs/my-_API.md#mutateObject)
+* [someUrl](docs/my-_API.md#someUrl)
 
 
 __Variables:__
 
-* [mutatorRules](docs/my-api.md#mutatorRules)
+* [mutatorRules](docs/my-_API.md#mutatorRules)
 
 ## abstractObject
 
@@ -102,15 +102,15 @@ exports[`markdown-api should provide markdown for homepage 1`] = `
 
 __Functions:__
 
-* [abstractObject](api.md#abstractObject)
-* [anyOfString](api.md#anyOfString)
-* [mutateObject](api.md#mutateObject)
-* [someUrl](api.md#someUrl)
+* [abstractObject](API.md#abstractObject)
+* [anyOfString](API.md#anyOfString)
+* [mutateObject](API.md#mutateObject)
+* [someUrl](API.md#someUrl)
 
 
 __Variables:__
 
-* [mutatorRules](api.md#mutatorRules)
+* [mutatorRules](API.md#mutatorRules)
 
 ## abstractObject
 
@@ -197,15 +197,15 @@ exports[`markdown-api should provide markdown without homepage 1`] = `
 
 __Functions:__
 
-* [abstractObject](api.md#abstractObject)
-* [anyOfString](api.md#anyOfString)
-* [mutateObject](api.md#mutateObject)
-* [someUrl](api.md#someUrl)
+* [abstractObject](API.md#abstractObject)
+* [anyOfString](API.md#anyOfString)
+* [mutateObject](API.md#mutateObject)
+* [someUrl](API.md#someUrl)
 
 
 __Variables:__
 
-* [mutatorRules](api.md#mutatorRules)
+* [mutatorRules](API.md#mutatorRules)
 
 ## abstractObject
 


### PR DESCRIPTION

# Summary of the change

Rename api.md to API.md

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Motivation and context

For naming consistency for other markdown files, all files should be in uppercase.

# How Has This Been Tested?

Unit tests and manually.

